### PR TITLE
Add block_num & global_sequence parameters for get_actions

### DIFF
--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -57,6 +57,8 @@ Get past actions based on notified account.
 | skip | query | Skip [n] actions (pagination) | No | integer |
 | limit | query | Limit of [n] actions per page | No | integer |
 | sort | query | Sort direction ('desc', 'asc', '1' or '-1') | No | string |
+| block_num | query | Filter actions in block_num range [from]-[to] | No | string |
+| global_sequence | query | Filter actions in global_sequence range [from]-[to] | No | string |
 | after | query | Filter actions after specified date (ISO8601) | No | string |
 | before | query | Filter actions before specified date (ISO8601) | No | string |
 | simple | query | Simplified output mode | No | boolean |

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -57,8 +57,8 @@ Get past actions based on notified account.
 | skip | query | Skip [n] actions (pagination) | No | integer |
 | limit | query | Limit of [n] actions per page | No | integer |
 | sort | query | Sort direction ('desc', 'asc', '1' or '-1') | No | string |
-| block_num | query | Filter actions in block_num range [from]-[to] | No | string |
-| global_sequence | query | Filter actions in global_sequence range [from]-[to] | No | string |
+| block_num | query | Filter actions by block_num range [from]-[to] | No | string |
+| global_sequence | query | Filter actions by global_sequence range [from]-[to] | No | string |
 | after | query | Filter actions after specified date (ISO8601) | No | string |
 | before | query | Filter actions before specified date (ISO8601) | No | string |
 | simple | query | Simplified output mode | No | boolean |


### PR DESCRIPTION
Those usefull parameters weren't on the doc, i found them after someone told me on TG but by then i had already coded my script using before and after... if those were in the doc when i started it would have saved me few hours. 