### PR TITLE
docs(api): hot_first_actions / hot_first_window + hot_only for get_actions

### DIFF
--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -62,9 +62,9 @@ Get past actions based on notified account.
 | after | query | Filter actions after specified date (ISO8601) | No | string |
 | before | query | Filter actions before specified date (ISO8601) | No | string |
 | simple | query | Simplified output mode | No | boolean |
-| noBinary | query | exclude large binary data | No | boolean
-| checkLib | query | perform reversibility check | No | boolean
-| hot_only | query | Search only the newest action partition(s) instead of the full history. Useful for fetching the latest actions without fanning out across old shards | No | boolean
+| noBinary | query | exclude large binary data | No | boolean |
+| checkLib | query | perform reversibility check | No | boolean |
+| hot_only | query | Search only the newest action partition(s) instead of the full history. Useful for fetching the latest actions without fanning out across old shards | No | boolean |
 
 
 !!! note

--- a/docs/api/v2.md
+++ b/docs/api/v2.md
@@ -64,6 +64,7 @@ Get past actions based on notified account.
 | simple | query | Simplified output mode | No | boolean |
 | noBinary | query | exclude large binary data | No | boolean
 | checkLib | query | perform reversibility check | No | boolean
+| hot_only | query | Search only the newest action partition(s) instead of the full history. Useful for fetching the latest actions without fanning out across old shards | No | boolean
 
 
 !!! note

--- a/docs/providers/setup/chain.md
+++ b/docs/providers/setup/chain.md
@@ -21,7 +21,7 @@ with its default value and an example of real usage.
   - `"get_links": 1000`
   - `"get_deltas": 1000`
 - `"access_log": false` ⇒ Enable log API access.
-- `"hot_first_actions": false` ⇒ When enabled, an unbounded newest-first `get_actions` account poll (e.g. `?account=eosio.token`, `sort=desc`, no `before`/`after`, no pagination) searches only the most recent action partition(s) first, widening to the full index set **only** if that window returns fewer than `limit` hits. Keeps high-frequency polling for the latest actions off the older/warm shards. Default off; safe to enable without reindexing. *(Note: while a poll is served from the hot window, the response `total` reflects that window only.)*
+- `"hot_first_actions": false` ⇒ When enabled, an unbounded newest-first `get_actions` account poll (e.g. `?account=eosio.token&sort=desc`, no `before`/`after`, no pagination) searches only the most recent action partition(s) first, widening to the full index set **only** if that window returns fewer than `limit` hits. Keeps high-frequency polling for the latest actions off the older/warm shards. Default off; safe to enable without reindexing. *(Note: while a poll is served from the hot window, the response `total` reflects that window only.)*
 - `"hot_first_window": 2` ⇒ Number of newest action partitions searched in the hot window when `hot_first_actions` is enabled. Default `2` (covers the live partition plus the previous one across a rollover).
 - `"explorer"` ⇒ Explorer configuration (see [Explorer Setup](../explorer.md))
     - `"upstream": "http://127.0.0.1:4777"` ⇒ URL of the Explorer SSR server

--- a/docs/providers/setup/chain.md
+++ b/docs/providers/setup/chain.md
@@ -21,6 +21,8 @@ with its default value and an example of real usage.
   - `"get_links": 1000`
   - `"get_deltas": 1000`
 - `"access_log": false` ⇒ Enable log API access.
+- `"hot_first_actions": false` ⇒ When enabled, an unbounded newest-first `get_actions` account poll (e.g. `?account=eosio.token`, `sort=desc`, no `before`/`after`, no pagination) searches only the most recent action partition(s) first, widening to the full index set **only** if that window returns fewer than `limit` hits. Keeps high-frequency polling for the latest actions off the older/warm shards. Default off; safe to enable without reindexing. *(Note: while a poll is served from the hot window, the response `total` reflects that window only.)*
+- `"hot_first_window": 2` ⇒ Number of newest action partitions searched in the hot window when `hot_first_actions` is enabled. Default `2` (covers the live partition plus the previous one across a rollover).
 - `"explorer"` ⇒ Explorer configuration (see [Explorer Setup](../explorer.md))
     - `"upstream": "http://127.0.0.1:4777"` ⇒ URL of the Explorer SSR server
     - `"theme": "default"` ⇒ Theme name (matches `<name>.theme.mjs` in explorer/themes/)
@@ -159,6 +161,8 @@ to `chains/eos.config.json`. The next step is to edit the file as the following:
       "get_deltas": 1000
     },
     "access_log": false,
+    "hot_first_actions": false,
+    "hot_first_window": 2,
     "explorer": {
       "upstream": "http://127.0.0.1:4777",
       "theme": "default",


### PR DESCRIPTION
Documents the new hot-first routing for `get_actions` account polls, paired with **eosrio/hyperion-history-api#176**.

## Changes
- **`providers/setup/chain.md`** — adds `hot_first_actions` (default off) and `hot_first_window` (default 2) to the API configuration reference and the example `config.json`. Notes the `total`-reflects-hot-window caveat and that it's safe to enable without reindexing.
- **`api/v2.md`** — adds the previously-undocumented `hot_only` query param to the `/v2/history/get_actions` parameter table.

## Notes
- Pure markdown additions to existing structures (config bullet list, example JSON, endpoint param table) — no nav or structural changes.
- Merge alongside / after the code PR ships, since `hot_first_actions` lands in `dev` (next 4.x maintenance release).
