### PR TITLE
docs(chain): document features.index_deltas_deletions

### DIFF
--- a/docs/providers/setup/chain.md
+++ b/docs/providers/setup/chain.md
@@ -103,6 +103,7 @@ Whitelist for actions and deltas
 - `"index_deltas": true` ⇒ Index common table deltas (see delta on definitions/mappings)
 - `"index_transfer_memo": true` ⇒ Index transfers memo
 - `"index_all_deltas": true` ⇒ Index all table deltas
+- `"index_deltas_deletions": false` ⇒ Also index row deletions (deltas with `present=0`) so they appear in `get_deltas` (query with `&present=0` for removals only). Off by default; enabling it adds index volume on high-churn tables and only affects blocks indexed afterwards — reindex the affected range to backfill past deletions.
 
 #### 7.1 Streaming
 
@@ -238,7 +239,8 @@ to `chains/eos.config.json`. The next step is to edit the file as the following:
     },
     "index_deltas": true,
     "index_transfer_memo": true,
-    "index_all_deltas": true
+    "index_all_deltas": true,
+    "index_deltas_deletions": false
   },
   "prefetch": {
     "read": 50,


### PR DESCRIPTION
Documents the new opt-in indexer feature flag `features.index_deltas_deletions`.

When enabled (default `false`), the indexer writes row deletions (contract_row deltas with `present=0`) to the delta history index, so they appear in `get_deltas` (and can be isolated with `&present=0`). Previously only `present=1` create/modify rows were indexed, so removals were invisible.

The doc note also calls out the trade-offs:
- Extra index volume on high-churn tables (hence default off).
- Only affects blocks indexed after enabling — a reindex of the affected range is required to backfill past deletions.

Pairs with the indexer change adding the flag (on `dev` and `release/4.5`).